### PR TITLE
Devnet Release Readiness Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ If you want to...
 - **read our project management documentation**, check out the [website](https://pm.optimism.io).
 - **contribute to our project management documentation**, check out the [`src`](./src) directory.
 
+## Development
+
+To serve the mdbook locally to view your changes run `just serve`.
+
 ## Deployments
 
 The website is updated every 3 hours by a scheluded deployment job with what's in the `main` branch.

--- a/justfile
+++ b/justfile
@@ -1,2 +1,15 @@
+# The default recipe when just is called without arguments
+default: serve
+
+serve:
+    mdbook serve
+
+test:
+    just lint
+    mdbook build
+
+lint:
+    markdownlint-cli2 "**/*.md"
+
 lint-fix:
     markdownlint-cli2 --fix "**/*.md"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -3,4 +3,6 @@
 - [SDLC](./sdlc.md)
 - [Release Process](./release-process.md)
     - [Release Calendar](./release-calendar.md)
-    - [Acceptance Testing](./acceptance-testing.md)
+    - [Acceptance Testing](./acceptance-testing/index.md)
+        - [Release Readiness Process (RRP)](./acceptance-testing/release-readiness.md)
+        - [Release Readiness Checklist (RRC)](./acceptance-testing/release-checklist.md)

--- a/src/acceptance-testing/index.md
+++ b/src/acceptance-testing/index.md
@@ -4,7 +4,7 @@ Acceptance testing ensures OP Stack networks are feature-complete, reliable, and
 
 The Platforms team will compile a Release Readiness Process (RRP) document, which will outline how to acceptance test devnets. This will include a list of tests to run - the Release Readiness Checklist (RRC). They will originally be run manually, but we'll automate them over time.
 
-By automating validation and enforcing quality gates, we reduce risk and increase confidence in releases. Much of this is facilitated by a new tool, op-acceptor, which can run standard Go tests against OP Stack networks and track that network’s readiness for promotion. Acceptance testing is a prerequisite for networks to promote from Alphanet, to Betanet, to Testnet.
+By automating validation and enforcing quality gates, we reduce risk and increase confidence in releases. Much of this is facilitated by a new tool, op-acceptor, which can run standard Go tests against OP Stack networks and track that network's readiness for promotion. Acceptance testing is a prerequisite for networks to promote from Alphanet, to Betanet, to Testnet.
 
 This is a shared responsibility between the Platforms and the feature teams:
 
@@ -25,9 +25,9 @@ The acceptance tests themselves are written in Go and are run by **op-acceptor**
 [op-acceptor](https://github.com/ethereum-optimism/infra/tree/main/op-acceptor) provides a high-level framework for registering, running and viewing the results of acceptance tests.
 
 <div style="width: 80%; margin: 0 auto;">
-    <img src="./acceptance-testing/op-acceptor.png" alt="op-acceptor screenshot" />
+    <img src="./op-acceptor.png" alt="op-acceptor screenshot" />
 </div>
 
 
 ## Tests
-To add new acceptance tests see the [README](https://github.com/ethereum-optimism/optimism/blob/develop/op-acceptance-tests/README.md#adding-new-tests) for instructions on how to do this.
+To add new acceptance tests see the [README](https://github.com/ethereum-optimism/optimism/blob/develop/op-acceptance-tests/README.md#adding-new-tests) for instructions on how to do this. 

--- a/src/acceptance-testing/release-checklist.md
+++ b/src/acceptance-testing/release-checklist.md
@@ -5,6 +5,7 @@ The most up-to-date list can be found in the Optimism monorepo's [op-acceptance-
 
 
 1. **Network Liveness**
+   - Run the 'base' op-acceptor gate to run non-feature specific checks
    - New blocks are being produced at the expected rate
    - Transactions can be submitted and included in blocks
    - Confirm deposits work
@@ -12,8 +13,8 @@ The most up-to-date list can be found in the Optimism monorepo's [op-acceptance-
    - Confirm that chains do not fork
 
 2. **Network Health**
-   - The SLA dashboard is checked
-   - Alerts for the devnet are checked
+   - The [SLA dashboard](https://optimistic.grafana.net/goto/WGOaGN1NR?orgId=1) is checked; there should be no SLA breaches
+   - Alerts for the devnet are checked; there should be no P1 alerts
 
 3. **Feature Verification**
    - Run the appropriate op-acceptor gate for the network

--- a/src/acceptance-testing/release-checklist.md
+++ b/src/acceptance-testing/release-checklist.md
@@ -13,8 +13,10 @@ The most up-to-date list can be found in the Optimism monorepo's [op-acceptance-
    - Confirm that chains do not fork
 
 2. **Network Health**
-   - The [SLA dashboard](https://optimistic.grafana.net/goto/WGOaGN1NR?orgId=1) is checked; there should be no SLA breaches
-   - Alerts for the devnet are checked; there should be no P1 alerts
+   - The [SLA dashboard](https://optimistic.grafana.net/goto/WGOaGN1NR?orgId=1)
+      - No SLA breaches
+   - Alerts for the devnet
+      - All P1 alerts have either been addressed or have a remediation plan
 
 3. **Feature Verification**
    - Run the appropriate op-acceptor gate for the network

--- a/src/acceptance-testing/release-checklist.md
+++ b/src/acceptance-testing/release-checklist.md
@@ -1,0 +1,33 @@
+# Release Readiness Checklist (RRC)
+
+*Coming soon*
+
+This document will provide a detailed checklist of requirements that devnets must meet to be considered ready for release. The checklist will include specific tests, metrics, and criteria that are evaluated as part of the [Release Readiness](./release-readiness.md) process. 
+The most up-to-date list can be found in the Optimism monorepo's [op-acceptance-tests](https://github.com/ethereum-optimism/optimism/tree/develop/op-acceptance-tests). 
+
+The tests will include, but not be limited to topics such as:
+
+1. **Network Liveness**
+   - Blocks are being produced at the expected rate
+   - Transactions can be submitted and included in blocks
+   - The network recovers gracefully from disruptions
+
+2. **Feature Verification**
+   - Each feature functions according to its specifications
+   - Features interact correctly with each other
+   - Backward compatibility is maintained where required
+
+3. **Upgrade Process**
+   - The upgrade can be executed successfully
+   - Rollback procedures are validated if applicable
+   - Node operators can follow the upgrade process without issues
+
+4. **Performance Benchmarks**
+   - Transaction throughput meets expectations
+   - Block production latency is within acceptable ranges
+   - Resource utilization (CPU, memory, storage) is within sustainable limits
+
+5. **Security Verification**
+   - No known security vulnerabilities exist
+   - Access controls function as expected
+   - Critical operations are properly secured

--- a/src/acceptance-testing/release-checklist.md
+++ b/src/acceptance-testing/release-checklist.md
@@ -3,6 +3,8 @@
 This document provides a detailed checklist of requirements that devnets must meet to be considered ready for release. These are specific tests, metrics, and criteria that are evaluated as part of the [Release Readiness](./release-readiness.md) process. 
 The most up-to-date list can be found in the Optimism monorepo's [op-acceptance-tests](https://github.com/ethereum-optimism/optimism/tree/develop/op-acceptance-tests). 
 
+TODO: We need to revisit this document to define how we'll treat different devnet types (localnet, alphanet, betanet, etc.). For example, the list items may remain the same but we'd modify the stringency/thresholds.
+
 
 1. **Network Liveness**
    - Run the 'base' op-acceptor gate to run non-feature specific checks

--- a/src/acceptance-testing/release-checklist.md
+++ b/src/acceptance-testing/release-checklist.md
@@ -1,33 +1,19 @@
 # Release Readiness Checklist (RRC)
 
-*Coming soon*
-
-This document will provide a detailed checklist of requirements that devnets must meet to be considered ready for release. The checklist will include specific tests, metrics, and criteria that are evaluated as part of the [Release Readiness](./release-readiness.md) process. 
+This document provides a detailed checklist of requirements that devnets must meet to be considered ready for release. These are specific tests, metrics, and criteria that are evaluated as part of the [Release Readiness](./release-readiness.md) process. 
 The most up-to-date list can be found in the Optimism monorepo's [op-acceptance-tests](https://github.com/ethereum-optimism/optimism/tree/develop/op-acceptance-tests). 
 
-The tests will include, but not be limited to topics such as:
 
 1. **Network Liveness**
-   - Blocks are being produced at the expected rate
+   - New blocks are being produced at the expected rate
    - Transactions can be submitted and included in blocks
-   - The network recovers gracefully from disruptions
+   - Confirm deposits work
+   - Confirm we can send transaction on L2
+   - Confirm that chains do not fork
 
-2. **Feature Verification**
-   - Each feature functions according to its specifications
-   - Features interact correctly with each other
-   - Backward compatibility is maintained where required
+2. **Network Health**
+   - The SLA dashboard is checked
+   - Alerts for the devnet are checked
 
-3. **Upgrade Process**
-   - The upgrade can be executed successfully
-   - Rollback procedures are validated if applicable
-   - Node operators can follow the upgrade process without issues
-
-4. **Performance Benchmarks**
-   - Transaction throughput meets expectations
-   - Block production latency is within acceptable ranges
-   - Resource utilization (CPU, memory, storage) is within sustainable limits
-
-5. **Security Verification**
-   - No known security vulnerabilities exist
-   - Access controls function as expected
-   - Critical operations are properly secured
+3. **Feature Verification**
+   - Run the appropriate op-acceptor gate for the network

--- a/src/acceptance-testing/release-readiness.md
+++ b/src/acceptance-testing/release-readiness.md
@@ -99,3 +99,6 @@ Here are some ideas for future iterations of this process:
   1. The op-acceptor dashboard, showing test status and results
   2. A Release Readiness Report documenting all tests, issues, and recommendations
   3. Updates in the weekly Protocol Upgrades Call
+* Security
+  1. We should explicitly define what we're checking for and how we do it
+  2. For checking smart contracts, we could utilise a tool such as [solcurity](https://github.com/transmissions11/solcurity)

--- a/src/acceptance-testing/release-readiness.md
+++ b/src/acceptance-testing/release-readiness.md
@@ -4,7 +4,7 @@
 
 This document defines the process and expectations for devnet releases in the OP Stack. It establishes a consistent framework for determining when a devnet is ready for release and how pass/fail determinations are made. By following these procedures, we can ensure that devnets meet quality standards before release.
 
-While the Platforms team serves as the primary custodian of this release readiness process, its success relies on collaborative ownership with Protocol and contributions from across the organization.
+While the Platforms team serves as the primary custodian of this release readiness process, its success relies on collaborative ownership between Platforms and Protocol as well as contributions from across the organization.
 
 ## Roles and Responsibilities
 
@@ -28,7 +28,7 @@ The primary objectives of the Devnet Release Readiness process are:
 Before a devnet can be considered for release, the following prerequisites must be met:
 
 1. All new features must have acceptance testing coverage in [op-acceptance-tests](https://github.com/ethereum-optimism/optimism/tree/main/op-acceptance-tests)
-2. The acceptance tests, as defined by the Release Readiness Checklist, should be passing
+2. The acceptance tests, as defined by the Release Readiness Checklist, should be passing on a local kurtosis-based devnet
 
 ### Readiness Phases
 
@@ -37,7 +37,7 @@ The devnets are expected to be live for short periods of time. For example, alph
 #### 1. Deployment
 
 - A devnet is deployed according to the [standard process](https://github.com/ethereum-optimism/devnets/blob/main/README.md)
-- Basic infrastructure checks ensure the network is operational
+- Basic infrastructure checks ensure the network is operational (manually for now; to be automated)
 
 
 #### 2. Acceptance Testing
@@ -45,7 +45,7 @@ In this phase we work through the Release Readiness Checklist.
 - Automated acceptance tests are run using op-acceptor
 - Manual acceptance tests are run
   - Feature teams run specific feature tests
-  - Platform runs security and load testing
+  - Platform runs security and load tests
 
 #### 3. Results Analysis
 

--- a/src/acceptance-testing/release-readiness.md
+++ b/src/acceptance-testing/release-readiness.md
@@ -104,3 +104,4 @@ Here are some ideas for future iterations of this process:
 * Security
   1. We should explicitly define what we're checking for and how we do it
   2. For checking smart contracts, we could utilise a tool such as [solcurity](https://github.com/transmissions11/solcurity)
+  3. [Audit](https://github.com/ethereum-optimism/pm/pull/49) procurement and execution

--- a/src/acceptance-testing/release-readiness.md
+++ b/src/acceptance-testing/release-readiness.md
@@ -46,6 +46,7 @@ In this phase we work through the Release Readiness Checklist.
 - Manual acceptance tests are run
   - Feature teams run specific feature tests
   - Platform runs security and load tests
+- Exploratory testing is run by all teams (probing of the system looking for things that we previously missed)
 
 #### 3. Results Analysis
 
@@ -58,7 +59,7 @@ In this phase we work through the Release Readiness Checklist.
 #### 4. Release Determination
 
 - The Platforms team makes the final pass/fail determination
-- A devnet must have ZERO critical issues to be considered for promotion
+- A devnet must have ZERO catastrophic or critical issues (SEV 0 or 1) to be considered for promotion
 - Major issues must have mitigation plans before promotion
 - Minor issues are documented but don't block promotion
 

--- a/src/acceptance-testing/release-readiness.md
+++ b/src/acceptance-testing/release-readiness.md
@@ -2,27 +2,24 @@
 
 ## Overview
 
-This document defines the process and expectations for devnet releases in the OP Stack. It establishes a consistent framework for determining when a devnet is ready for release, how results are communicated, and how pass/fail determinations are made. By following these procedures, we can ensure that devnets meet quality standards before promotion, reducing the risk of critical bugs reaching production networks.
-
-## Roles and Responsibilities
+This document defines the process and expectations for devnet releases in the OP Stack. It establishes a consistent framework for determining when a devnet is ready for release and how pass/fail determinations are made. By following these procedures, we can ensure that devnets meet quality standards before release.
 
 While the Platforms team serves as the primary custodian of this release readiness process, its success relies on collaborative ownership with Protocol and contributions from across the organization.
 
+## Roles and Responsibilities
+
 | Role | Responsibilities |
 |------|-----------------|
-| **Platforms Team** | • Maintain the Release Readiness Process (RRP)<br>• Run acceptance tests<br>• Make final pass/fail determinations<br>• Communicate test results to stakeholders |
-| **Feature Teams** | • Write acceptance tests for specific features<br>• Run feature-specific tests<br>• Fix identified issues in their features<br>• Provide input on severity of identified issues |
-| **Release Coordinator** | • Coordinate the overall release process<br>• Track progress against the Release Readiness Checklist<br>• Facilitate communication between teams<br>• Document release decisions and rationales |
+| **Platforms Team** | • Maintain the Release Readiness Process<br>• Run acceptance tests<br>• Make final pass/fail determinations |
+| **Feature Teams** | • Write and run feature-specific tests<br>• Fix identified issues in their features |
 
 ## Objectives
 
 The primary objectives of the Devnet Release Readiness process are:
 
 1. Release production networks without critical bugs
-2. Ensure high feature coverage through comprehensive testing
+2. Ensure feature coverage through comprehensive testing
 3. Establish a clear process for devnet promotion decisions
-4. Provide visibility into the release readiness of devnets
-5. Define responsibilities for teams involved in the release process
 
 ## Release Readiness Process
 
@@ -30,96 +27,75 @@ The primary objectives of the Devnet Release Readiness process are:
 
 Before a devnet can be considered for release, the following prerequisites must be met:
 
-1. All required features must be deployed to the devnet
-2. A Release Readiness Checklist (RRC) must be defined for the devnet
-3. The [op-acceptor](https://github.com/ethereum-optimism/infra/tree/main/op-acceptor) testing framework must be configured for the devnet
+1. All new features must have acceptance testing coverage in [op-acceptance-tests](https://github.com/ethereum-optimism/optimism/tree/main/op-acceptance-tests)
+2. The acceptance tests, as defined by the Release Readiness Checklist, should be passing
 
 ### Readiness Phases
 
-The devnets are expected to be live for short periods of time. For example, alphanets will be decomissioned after three weeks. This time will be roughly spent in five phases.
+The devnets are expected to be live for short periods of time. For example, alphanets will be decomissioned after three weeks.
 
-#### 1. Initial Deployment
+#### 1. Deployment
 
 - A devnet is deployed according to the [standard process](https://github.com/ethereum-optimism/devnets/blob/main/README.md)
-- The Platforms team (Infrastructure Pod) verifies that all requested features are properly deployed
-- Basic infrastructure checks are performed to ensure the network is operational
-- When all looks good, the devnet is made live and public
+- Basic infrastructure checks ensure the network is operational
 
-#### 2. Public Usage
 
-- At this point the devnet is live; the general public is free to use & test with it
-- We collect any feedback
-
-#### 3. Acceptance Testing
-
-- All tests are executed against the [Release Readiness Checklist (RRC)](./release-checklist.md)
+#### 2. Acceptance Testing
+In this phase we work through the Release Readiness Checklist.
 - Automated acceptance tests are run using op-acceptor
-- For any manual tests remaining:
-    - Feature teams run specific feature tests
-    - Platform runs any other tests
-    - Platform runs injection testing (looking to see how we can break the network, test incident response runbooks, ensure monitoring and alerting is working)
-    - Platform runs load testing (validate performance under stress)
-    - Platform runs security testing
-- Test results are documented and tracked in the op-acceptor dashboard
+- Manual acceptance tests are run
+  - Feature teams run specific feature tests
+  - Platform runs security and load testing
 
-#### 4. Results Analysis
+#### 3. Results Analysis
 
-- Test results & feedback are categorized as:
+- Test results are categorized as:
   - **Critical Issues**: Bugs that would cause data loss, security vulnerabilities, or severe service disruption
   - **Major Issues**: Bugs that significantly impact functionality but don't compromise security or data integrity
   - **Minor Issues**: Non-critical bugs that have workarounds or minimal impact
 
-#### 5. Release Determination
+#### 4. Release Determination
 
-- The Platforms team, as custodians of the release process, makes the final pass/fail determination
+- The Platforms team makes the final pass/fail determination
 - A devnet must have ZERO critical issues to be considered for promotion
-- Major issues must have clear mitigation plans before promotion
-- Minor issues are documented and tracked but typically don't block promotion
+- Major issues must have mitigation plans before promotion
+- Minor issues are documented but don't block promotion
 
-## Communication and Documentation
-
-### Test Results Reporting
-
-Test results are communicated through:
-
-1. The op-acceptor dashboard, showing test status and results
-2. A Release Readiness Report documenting all tests, issues, and recommendations
-3. Updates in the weekly Protocol Upgrades Call
-
-### Release Decision Documentation
-
-For each devnet release decision, the following is documented:
-
-1. Summary of test results against the RRC
-2. List of any issues found and their severity
-3. Mitigation plans for identified issues
-4. Final pass/fail determination with rationale
-5. Recommendations for improvements in future releases
+#### 5. Release
+When ready, the devnet is made live and public.
 
 ## Integration with Existing Release Process
 
 The Devnet Release Readiness process integrates with the existing [Release Process](../release-process.md) as follows:
 
-1. **Alphanet**: Before a feature can be promoted from Alphanet to Betanet, it must pass the Devnet Release Readiness process
-2. **Betanet**: Before a Betanet can be promoted to Testnet, it must pass the Devnet Release Readiness process with stricter criteria
-3. **Testnet**: All features must have successfully passed through Alphanet and Betanet Release Readiness before deployment to Testnet
+1. **Alphanet**: Before promotion to Betanet, it must pass the Release Readiness process
+2. **Betanet**: Before promotion to Testnet, it must pass the Release Readiness process with stricter criteria
+3. **Testnet**: All features must have successfully passed through Alphanet and Betanet before deployment
 
 ## Enforcement
 
 Devnets shall not be released or promoted without following the release process described in this document. The Platforms team serves as the custodians of this document and guardians of the releases, with authority to block promotion of devnets that do not meet the release readiness criteria.
-
-## Continuous Improvement
-
-This process is subject to continuous improvement:
-
-1. After each release, a retrospective is conducted to identify process improvements
-2. The Release Readiness Checklist is updated based on new learning and changing requirements
-3. Test automation is expanded to reduce manual testing efforts
-4. Metrics are collected to measure the effectiveness of the process in preventing issues from reaching production
 
 ## Tools and Resources
 
 - [op-acceptor](https://github.com/ethereum-optimism/infra/tree/main/op-acceptor) - The acceptance testing framework
 - [op-acceptance-tests](https://github.com/ethereum-optimism/optimism/tree/develop/op-acceptance-tests) - Repository of acceptance tests
 - [devnets](https://devnets.optimism.io/) - The Optimism devnet environment
-- [Acceptance Testing](./index.md) - Additional context on acceptance testing process 
+- [Acceptance Testing](./index.md) - Additional context on acceptance testing process
+
+## Future Considerations and Improvements
+
+Here are some ideas for future iterations of this process:
+
+* After each release, a retrospective to identify process improvements
+* A Release Coordinator role to coordinate the overall release process, track progress, facilitate communication, and document decisions
+* A per-devnet Release Readiness Checklist (RRC) to define specific requirements for each devnet
+* Public usage phase to collect feedback from the general public
+* Injection testing to see how we can break the network and test incident response runbooks
+* Communication through dashboards and weekly calls
+* Detailed Release Decision Documentation including summary of test results, list of issues, mitigation plans, and recommendations
+* Test Results Reporting through the op-acceptor dashboard and Release Readiness Reports
+* Test results comms, including:
+  1. The op-acceptor dashboard, showing test status and results
+  2. A Release Readiness Report documenting all tests, issues, and recommendations
+  3. Updates in the weekly Protocol Upgrades Call

--- a/src/acceptance-testing/release-readiness.md
+++ b/src/acceptance-testing/release-readiness.md
@@ -29,6 +29,7 @@ Before a devnet can be considered for release, the following prerequisites must 
 
 1. All new features must have acceptance testing coverage in [op-acceptance-tests](https://github.com/ethereum-optimism/optimism/tree/main/op-acceptance-tests)
 2. The acceptance tests, as defined by the Release Readiness Checklist, should be passing on a local kurtosis-based devnet
+3. The [FMA](../fmas.md) for the in-scope features should have been started
 
 ### Readiness Phases
 

--- a/src/acceptance-testing/release-readiness.md
+++ b/src/acceptance-testing/release-readiness.md
@@ -41,7 +41,7 @@ The devnets are expected to be live for short periods of time. For example, alph
 
 
 #### 2. Acceptance Testing
-In this phase we work through the [Release Readiness Checklist](./release-checklist.md).
+We work through the [Release Readiness Checklist](./release-checklist.md), which includes:
 - Automated acceptance tests (using op-acceptor)
 - Manual acceptance tests
   - Feature teams run specific feature tests

--- a/src/acceptance-testing/release-readiness.md
+++ b/src/acceptance-testing/release-readiness.md
@@ -49,10 +49,11 @@ In this phase we work through the Release Readiness Checklist.
 
 #### 3. Results Analysis
 
-- Test results are categorized as:
-  - **Critical Issues**: Bugs that would cause data loss, security vulnerabilities, or severe service disruption
-  - **Major Issues**: Bugs that significantly impact functionality but don't compromise security or data integrity
-  - **Minor Issues**: Non-critical bugs that have workarounds or minimal impact
+- Each of the test results are categorized, in line with our internal incident severity matrix, by their potential impact had they been on mainnet:
+  - **Catastrophic (SEV 0)**: Critical to catastrophic issue that would warrant public notification, leadership awareness (and potential involvement), and potential consultation with legal. A large number of users are impacted by complete or severe loss of functionality, and SLAs have been broken
+  - **Critical (SEV 1)**: Critical issue that would warrant public notification. A large number of users are impacted by severe loss of functionality, and SLAs may have been broken
+  - **Major (SEV 2)**: A functionality issue that would actively impact many user' ability to transact, or a critical issue impacting a subset of users
+  - **Minor (SEV 3)**: Stability or minor customer-impacting issues that would require immediate attention from service owners
 
 #### 4. Release Determination
 

--- a/src/acceptance-testing/release-readiness.md
+++ b/src/acceptance-testing/release-readiness.md
@@ -41,12 +41,12 @@ The devnets are expected to be live for short periods of time. For example, alph
 
 
 #### 2. Acceptance Testing
-In this phase we work through the Release Readiness Checklist.
-- Automated acceptance tests are run using op-acceptor
-- Manual acceptance tests are run
+In this phase we work through the [Release Readiness Checklist](./release-checklist.md).
+- Automated acceptance tests (using op-acceptor)
+- Manual acceptance tests
   - Feature teams run specific feature tests
   - Platform runs security and load tests
-- Exploratory testing is run by all teams (probing of the system looking for things that we previously missed)
+  - Exploratory testing is run by all teams (probing of the system looking for things that we previously missed)
 
 #### 3. Results Analysis
 

--- a/src/acceptance-testing/release-readiness.md
+++ b/src/acceptance-testing/release-readiness.md
@@ -1,0 +1,125 @@
+# Release Readiness Process (RRP)
+
+## Overview
+
+This document defines the process and expectations for devnet releases in the OP Stack. It establishes a consistent framework for determining when a devnet is ready for release, how results are communicated, and how pass/fail determinations are made. By following these procedures, we can ensure that devnets meet quality standards before promotion, reducing the risk of critical bugs reaching production networks.
+
+## Roles and Responsibilities
+
+While the Platforms team serves as the primary custodian of this release readiness process, its success relies on collaborative ownership with Protocol and contributions from across the organization.
+
+| Role | Responsibilities |
+|------|-----------------|
+| **Platforms Team** | • Maintain the Release Readiness Process (RRP)<br>• Run acceptance tests<br>• Make final pass/fail determinations<br>• Communicate test results to stakeholders |
+| **Feature Teams** | • Write acceptance tests for specific features<br>• Run feature-specific tests<br>• Fix identified issues in their features<br>• Provide input on severity of identified issues |
+| **Release Coordinator** | • Coordinate the overall release process<br>• Track progress against the Release Readiness Checklist<br>• Facilitate communication between teams<br>• Document release decisions and rationales |
+
+## Objectives
+
+The primary objectives of the Devnet Release Readiness process are:
+
+1. Release production networks without critical bugs
+2. Ensure high feature coverage through comprehensive testing
+3. Establish a clear process for devnet promotion decisions
+4. Provide visibility into the release readiness of devnets
+5. Define responsibilities for teams involved in the release process
+
+## Release Readiness Process
+
+### Prerequisites
+
+Before a devnet can be considered for release, the following prerequisites must be met:
+
+1. All required features must be deployed to the devnet
+2. A Release Readiness Checklist (RRC) must be defined for the devnet
+3. The [op-acceptor](https://github.com/ethereum-optimism/infra/tree/main/op-acceptor) testing framework must be configured for the devnet
+
+### Readiness Phases
+
+The devnets are expected to be live for short periods of time. For example, alphanets will be decomissioned after three weeks. This time will be roughly spent in five phases.
+
+#### 1. Initial Deployment
+
+- A devnet is deployed according to the [standard process](https://github.com/ethereum-optimism/devnets/blob/main/README.md)
+- The Platforms team (Infrastructure Pod) verifies that all requested features are properly deployed
+- Basic infrastructure checks are performed to ensure the network is operational
+- When all looks good, the devnet is made live and public
+
+#### 2. Public Usage
+
+- At this point the devnet is live; the general public is free to use & test with it
+- We collect any feedback
+
+#### 3. Acceptance Testing
+
+- All tests are executed against the [Release Readiness Checklist (RRC)](./release-checklist.md)
+- Automated acceptance tests are run using op-acceptor
+- For any manual tests remaining:
+    - Feature teams run specific feature tests
+    - Platform runs any other tests
+    - Platform runs injection testing (looking to see how we can break the network, test incident response runbooks, ensure monitoring and alerting is working)
+    - Platform runs load testing (validate performance under stress)
+    - Platform runs security testing
+- Test results are documented and tracked in the op-acceptor dashboard
+
+#### 4. Results Analysis
+
+- Test results & feedback are categorized as:
+  - **Critical Issues**: Bugs that would cause data loss, security vulnerabilities, or severe service disruption
+  - **Major Issues**: Bugs that significantly impact functionality but don't compromise security or data integrity
+  - **Minor Issues**: Non-critical bugs that have workarounds or minimal impact
+
+#### 5. Release Determination
+
+- The Platforms team, as custodians of the release process, makes the final pass/fail determination
+- A devnet must have ZERO critical issues to be considered for promotion
+- Major issues must have clear mitigation plans before promotion
+- Minor issues are documented and tracked but typically don't block promotion
+
+## Communication and Documentation
+
+### Test Results Reporting
+
+Test results are communicated through:
+
+1. The op-acceptor dashboard, showing test status and results
+2. A Release Readiness Report documenting all tests, issues, and recommendations
+3. Updates in the weekly Protocol Upgrades Call
+
+### Release Decision Documentation
+
+For each devnet release decision, the following is documented:
+
+1. Summary of test results against the RRC
+2. List of any issues found and their severity
+3. Mitigation plans for identified issues
+4. Final pass/fail determination with rationale
+5. Recommendations for improvements in future releases
+
+## Integration with Existing Release Process
+
+The Devnet Release Readiness process integrates with the existing [Release Process](../release-process.md) as follows:
+
+1. **Alphanet**: Before a feature can be promoted from Alphanet to Betanet, it must pass the Devnet Release Readiness process
+2. **Betanet**: Before a Betanet can be promoted to Testnet, it must pass the Devnet Release Readiness process with stricter criteria
+3. **Testnet**: All features must have successfully passed through Alphanet and Betanet Release Readiness before deployment to Testnet
+
+## Enforcement
+
+Devnets shall not be released or promoted without following the release process described in this document. The Platforms team serves as the custodians of this document and guardians of the releases, with authority to block promotion of devnets that do not meet the release readiness criteria.
+
+## Continuous Improvement
+
+This process is subject to continuous improvement:
+
+1. After each release, a retrospective is conducted to identify process improvements
+2. The Release Readiness Checklist is updated based on new learning and changing requirements
+3. Test automation is expanded to reduce manual testing efforts
+4. Metrics are collected to measure the effectiveness of the process in preventing issues from reaching production
+
+## Tools and Resources
+
+- [op-acceptor](https://github.com/ethereum-optimism/infra/tree/main/op-acceptor) - The acceptance testing framework
+- [op-acceptance-tests](https://github.com/ethereum-optimism/optimism/tree/develop/op-acceptance-tests) - Repository of acceptance tests
+- [devnets](https://devnets.optimism.io/) - The Optimism devnet environment
+- [Acceptance Testing](./index.md) - Additional context on acceptance testing process 

--- a/src/sdlc.md
+++ b/src/sdlc.md
@@ -185,6 +185,7 @@ At this stage, you can start writing your code. Make sure you follow these stand
 
 - All consensus code must be behind a hardfork feature flag.
 - All changes must go through code review, and have test automation. Use CodeCov to determine how much of your code is tested, and to identify testing gaps.
+- For new features, add [acceptance tests](acceptance-testing.md).
 - All smart contract changes must meet the following minimum standards:
     - Follow the UX and Safety guidelines described [here](https://github.com/ethereum-optimism/design-docs/pull/177).
     - When upgrading existing contracts, follow the spec [here](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/l1-upgrades.md).


### PR DESCRIPTION
**Description**

This introduces an initial "Release Readiness" document, which aims to guide us in our devnet SDLC.
This work is part of [Milestone 3](https://github.com/ethereum-optimism/infra/milestone/10) of Acceptance Testing.
We'll later add specific tests to the "Release Checklist" document (an early draft also introduced here).
Both documents should be considered living; we'll be iterating on them as we learn and improve our process.

**Open Questions**
1. Do we want to track and publish results publicly, as I have suggested here? If so, where? A subpage within this repo/website would be my recommendation. Followed by a Discord notification to announce it.
2. Do we want to formalise the "Release Coordinator" role I have created and suggested here? This would essentially be a DRI to manage the end-to-end of a particular devnet; perhaps most importantly the publication of a finalised decision doc ("Release Decision Doc" in the text)
3. We've not yet introduced Security as a key part of this process; shall we? We could include security-oriented AT's.
4. For the process to be most successful we'll need contribution from various parts of the organization. Shall we explicitly call some out in the "Roles & Responsibilities" section? For example, PMO?

**Tests**

Served and viewed it locally.


**Metadata**

- Fixes https://github.com/ethereum-optimism/infra/issues/259
