### PR TITLE
Update website link to devdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository documents how the OP Stack is developed.
 
 If you want to...
 
-- **read our project management documentation**, check out the [website](https://pm.optimism.io).
+- **read our project management documentation**, check out the [website](https://devdocs.optimism.io/pm/).
 - **contribute to our project management documentation**, check out the [`src`](./src) directory.
 
 ## Development


### PR DESCRIPTION
The website was moved to https://devdocs.optimism.io/pm/

(The old one still works but I believe the devdocs site should be the canonical place).