### PR TITLE
Modify OPCM as part of SDLC

### DIFF
--- a/src/sdlc.md
+++ b/src/sdlc.md
@@ -191,7 +191,7 @@ At this stage, you can start writing your code. Make sure you follow these stand
     - When upgrading existing contracts, follow the spec [here](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/l1-upgrades.md).
     - Have near 100% test coverage along with invariant tests.
     - When useful, changes should be formally verified with Kontrol.
-    - Include any changes to OPCM and OPCMVerify.
+    - Include any changes to [OPCM](https://devdocs.optimism.io/contracts-bedrock/contributing/opcm.html) and VerifyOPCM.
 - All actions resulting from the FMA must be completed during implementation and will be reviewed by EVM Safety before the code can be deployed to a devnet.
 
 


### PR DESCRIPTION
**Description**

We always deploy and configure smart contracts through an OPCM contract, which always includes a VerifyOPCM contract on the side to mitigate risks during protocol upgrades. The changes ot OPCM and VerifyOPCM always need to be audited.

I've included the requirement to modify OPCM and VerifyOPCM in the step 2 (implementation), under the conditional for smart contract features. There is no need for anything else.

